### PR TITLE
Fix signout/signin process to reenable account choosing.

### DIFF
--- a/src/GoogleSignin.android.js
+++ b/src/GoogleSignin.android.js
@@ -88,7 +88,10 @@ class GoogleSignin {
         this._user = {...user};
 
         RNGoogleSignin.getAccessToken(user).then((token) => {
-          this._user.accessToken = token;
+          this._user = {
+            ...user,
+            accessToken: token
+          };
           this._removeListeners(sucessCb, errorCb);
           resolve(this._user);
         })
@@ -116,7 +119,10 @@ class GoogleSignin {
       const sucessCb = DeviceEventEmitter.addListener('RNGoogleSignInSuccess', (user) => {
         this._user = {...user};
         RNGoogleSignin.getAccessToken(user).then((token) => {
-          this._user.accessToken = token;
+          this._user = {
+            ...user,
+            accessToken: token
+          };
           this._removeListeners(sucessCb, errorCb);
           resolve(this._user);
         })

--- a/src/GoogleSignin.ios.js
+++ b/src/GoogleSignin.ios.js
@@ -83,7 +83,9 @@ class GoogleSignin {
   currentUserAsync() {
     return new Promise((resolve, reject) => {
       const sucessCb = NativeAppEventEmitter.addListener('RNGoogleSignInSuccess', (user) => {
-        this._user = user;
+        this._user = {
+          ...user,
+        };
         this._removeListeners(sucessCb, errorCb);
         resolve(user);
       });
@@ -104,7 +106,9 @@ class GoogleSignin {
   signIn() {
     return new Promise((resolve, reject) => {
       const sucessCb = NativeAppEventEmitter.addListener('RNGoogleSignInSuccess', (user) => {
-        this._user = user;
+        this._user = {
+          ...user,
+        };
         this.signinIsInProcess = false;
         this._removeListeners(sucessCb, errorCb);
         resolve(user);


### PR DESCRIPTION
This fix is based on https://github.com/devfd/react-native-google-signin/pull/174.

Note that I didn't pull in the changes to the GoogleSigninButton because they weren't relevant to us and I wasn't sure if they were correct.